### PR TITLE
Fix Atom feed issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-title:            John <em>A</em> <strong>De Goes</strong>
-text_title:       John A De Goes
+title:            John A De Goes
+rich_title:       John <em>A</em> <strong>De Goes</strong>
 tagline:          ramblings of a geek
 description:      The home on the web for technologist John A. De Goes.
 # Your site's domain goes here. Leave localhost server or blank when working locally.

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.text_title }}</title>
+<title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.title }}</title>
 <meta name="description" content="{{ page.description }}">
 <meta name="keywords" content="{{ page.tags | join: ', ' }}">
 {% if site.owner.twitter %}<!-- Twitter Cards -->
@@ -7,7 +7,7 @@
 <meta name="twitter:image" content="{{ site.url }}/images/{{ page.image.feature }}">
 {% else %}<meta name="twitter:card" content="summary">
 <meta name="twitter:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">{% endif %}
-<meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.text_title }}{% endif %}">
+<meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta name="twitter:creator" content="@{{ site.owner.twitter }}">{% endif %}
 
@@ -17,7 +17,7 @@
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-<meta property="og:site_name" content="{{ site.text_title }}">
+<meta property="og:site_name" content="{{ site.title }}">
 
 {% if site.google_verify %}<!-- Webmaster Tools verfication -->
 <meta name="google-site-verification" content="{{ site.google_verify }}">{% endif %}

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -1,6 +1,6 @@
 <div class="navigation-wrapper">
 	<div id="site-name" class="site-name">
-		<a href="{{ site.url }}/">{{ site.title }}</a>
+		<a href="{{ site.url }}/">{{ site.rich_title }}</a>
 	</div><!-- /.site-name -->
 	<div class="top-navigation">
 		<nav role="navigation" itemscope itemtype="https://schema.org/SiteNavigationElement">

--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 layout: none
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom" xml:lang="en">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
 <title type="text">{{ site.title }}</title>
 <subtitle type="text">{{ site.tagline }}</subtitle>
 <generator uri="https://github.com/mojombo/jekyll">Jekyll</generator>


### PR DESCRIPTION
Your Atom feed has some issues, and my RSS/Atom feed reader doesn't work, because SimplePie refuses to:

- <https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fdegoes.net%2Ffeed.xml>
- <https://simplepie.org/demo/?feed=https%3A%2F%2Fdegoes.net%2Ffeed.xml>

Problems identified:

- the Atom namespace is wrong, as it should be `http:`, not `https:` (this is the big one that breaks SimplePie);
- having `<em>` or other HTML tags inside `<title>` tags or inside HTML attributes is problematic;

Cheers,